### PR TITLE
Add vitest and basic app test

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/app.ts",
     "build": "tsc",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "test": "vitest"
   },
   "dependencies": {
     "@hono/node-server": "^1.14.1",
@@ -18,6 +19,7 @@
     "@types/node": "^20.11.19",
     "prisma": "^5.12.1",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.4.3"
+    "typescript": "^5.4.3",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,7 @@ import routes from './routes'
 import { swaggerUI } from '@hono/swagger-ui';
 import { OpenAPIHono } from '@hono/zod-openapi';
 
-const app = new OpenAPIHono();
+export const app = new OpenAPIHono();
 app.route('/', routes)
 
 app.doc('/openapi.json', {
@@ -17,12 +17,13 @@ app.get('/docs', swaggerUI({ url: '/openapi.json' }));
 app.get('/', (c) => {
   return c.text('Hello Hono!')
 })
+if (require.main === module) {
+  const port = parseInt(process.env.PORT || '3000')
+  console.log(`🚀 Server running http://localhost:${port}`)
 
-const port = parseInt(process.env.PORT || '3000')
-console.log(`🚀 Server running http://localhost:${port}`)
-
-serve({
-  fetch: app.fetch,
-  port,
-  hostname: '0.0.0.0'
-})
+  serve({
+    fetch: app.fetch,
+    port,
+    hostname: '0.0.0.0'
+  })
+}

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest'
+import { app } from '../src/app'
+
+describe('app', () => {
+  it('GET /openapi.json returns 200', async () => {
+    const res = await app.request('/openapi.json')
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
## Summary
- export the Hono app instance and avoid starting the server when imported
- add vitest to devDependencies and define npm test script
- create a simple test verifying `/openapi.json` returns HTTP 200

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d7152c49c832c90b1461d29705308